### PR TITLE
Wip/icon view

### DIFF
--- a/data/gtk-style.css
+++ b/data/gtk-style.css
@@ -1,8 +1,14 @@
 /* This file is part of GNOME Games. License: GPLv3 */
 
+@define-color games_collection_bg_color #292929;
+
 @define-color games_thumbnail_color #bebebe;
 @define-color games_thumbnail_border_color #3b3c38;
 @define-color games_thumbnail_bg_color #2d2d2d;
+
+GamesCollectionIconView.frame {
+	background-color: @games_collection_bg_color;
+}
 
 GamesGameThumbnail {
 	background-color: @games_thumbnail_bg_color;

--- a/data/gtk-style.css
+++ b/data/gtk-style.css
@@ -1,0 +1,13 @@
+/* This file is part of GNOME Games. License: GPLv3 */
+
+@define-color games_thumbnail_color #bebebe;
+@define-color games_thumbnail_border_color #3b3c38;
+@define-color games_thumbnail_bg_color #2d2d2d;
+
+GamesGameThumbnail {
+	background-color: @games_thumbnail_bg_color;
+	border: 1px;
+	border-radius: 2px;
+	border-color: @games_thumbnail_border_color;
+	color: @games_thumbnail_color;
+}

--- a/data/org.gnome.Games.gresource.xml
+++ b/data/org.gnome.Games.gresource.xml
@@ -3,6 +3,7 @@
   <gresource prefix="/org/gnome/Games">
     <file>gtk-style.css</file>
     <file preprocess="xml-stripblanks">ui/application-window.ui</file>
+    <file preprocess="xml-stripblanks">ui/collection-icon-view.ui</file>
     <file preprocess="xml-stripblanks">ui/game-icon-view.ui</file>
   </gresource>
 </gresources>

--- a/data/org.gnome.Games.gresource.xml
+++ b/data/org.gnome.Games.gresource.xml
@@ -3,5 +3,6 @@
   <gresource prefix="/org/gnome/Games">
     <file>gtk-style.css</file>
     <file preprocess="xml-stripblanks">ui/application-window.ui</file>
+    <file preprocess="xml-stripblanks">ui/game-icon-view.ui</file>
   </gresource>
 </gresources>

--- a/data/org.gnome.Games.gresource.xml
+++ b/data/org.gnome.Games.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/org/gnome/Games">
+    <file>gtk-style.css</file>
     <file preprocess="xml-stripblanks">ui/application-window.ui</file>
   </gresource>
 </gresources>

--- a/data/ui/application-window.ui
+++ b/data/ui/application-window.ui
@@ -16,17 +16,9 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
+              <object class="GamesCollectionIconView" id="collection_icon_view">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkIconView" id="games_icon_view">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="margin">6</property>
-                  </object>
-                </child>
+                <signal name="game-activated" handler="on_game_activated"/>
               </object>
               <packing>
                 <property name="name">page0</property>

--- a/data/ui/collection-icon-view.ui
+++ b/data/ui/collection-icon-view.ui
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <template class="GamesCollectionIconView" parent="GtkScrolledWindow">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="shadow-type">in</property>
+    <property name="hscrollbar-policy">never</property>
+    <property name="vscrollbar-policy">automatic</property>
+    <property name="kinetic-scrolling">True</property>
+    <property name="overlay-scrolling">True</property>
+    <style>
+      <class name="content-view"/>
+    </style>
+    <child>
+      <object class="GtkFlowBox" id="flow_box">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="valign">start</property>
+        <property name="margin-start">28</property>
+        <property name="margin-end">28</property>
+        <property name="margin-top">21</property>
+        <property name="margin-bottom">21</property>
+        <property name="homogeneous">True</property>
+        <property name="column-spacing">42</property>
+        <property name="row-spacing">21</property>
+        <property name="selection-mode">none</property>
+        <signal name="child-activated" handler="on_child_activated"/>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/ui/game-icon-view.ui
+++ b/data/ui/game-icon-view.ui
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <template class="GamesGameIconView" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GamesGameThumbnail" id="thumbnail">
+        <property name="visible">True</property>
+        <property name="width-request">128</property>
+        <property name="height-request">128</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="title">
+        <property name="visible">True</property>
+        <property name="width-request">128</property>
+        <property name="ellipsize">middle</property>
+        <property name="justify">center</property>
+        <property name="lines">2</property>
+        <property name="max-width-chars">0</property>
+        <property name="wrap">True</property>
+        <property name="wrap-mode">word</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="subtitle">
+        <property name="visible">True</property>
+        <property name="width-request">128</property>
+        <property name="ellipsize">middle</property>
+        <property name="justify">center</property>
+        <property name="lines">1</property>
+        <property name="max-width-chars">0</property>
+        <property name="wrap">True</property>
+        <property name="wrap-mode">word</property>
+        <style>
+          <class name="dim-label"/>
+        </style>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">False</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ gnome_games_SOURCES = \
 	\
 	ui/application.vala \
 	ui/application-window.vala \
+	ui/collection-icon-view.vala \
 	ui/game-icon-view.vala \
 	ui/game-thumbnail.vala \
 	\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ gnome_games_SOURCES = \
 	\
 	ui/application.vala \
 	ui/application-window.vala \
+	ui/game-icon-view.vala \
 	ui/game-thumbnail.vala \
 	\
 	main.vala \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ gnome_games_SOURCES = \
 	\
 	ui/application.vala \
 	ui/application-window.vala \
+	ui/game-thumbnail.vala \
 	\
 	main.vala \
 	$(BUILT_SOURCES) \

--- a/src/main.vala
+++ b/src/main.vala
@@ -1,3 +1,5 @@
+// This file is part of GNOME Games. License: GPLv3
+
 int main (string[] args) {
 	var app = new Games.Application ();
 	return app.run (args);

--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -2,27 +2,25 @@
 
 [GtkTemplate (ui = "/org/gnome/Games/ui/application-window.ui")]
 private class Games.ApplicationWindow : Gtk.ApplicationWindow {
-	Gtk.ListStore games_list_store;
+	ListStore collection;
 
 	[GtkChild]
-	Gtk.IconView games_icon_view;
+	CollectionIconView collection_icon_view;
 
 	public void load_game_list () {
-		this.games_list_store = new Gtk.ListStore (2, typeof (string),
-		                                              typeof (Gdk.Pixbuf));
-		games_icon_view.set_model (games_list_store);
-		games_icon_view.set_text_column (0);
-		games_icon_view.set_pixbuf_column (1);
+		this.collection = new ListStore (typeof (Game));
 
-		var theme = Gtk.IconTheme.get_default ();
-		var pixbuf = theme.load_icon ("input-gaming", 64, 0);
-
-		var game_source = new Games.DummyGameSource ();
-		game_source.each_game ((game) => {
-			Gtk.TreeIter iter;
-			games_list_store.append (out iter);
-			games_list_store.set (iter, 0, game.name,
-			                            1, pixbuf);
+		var dummy_source = new Games.DummyGameSource ();
+		dummy_source.each_game ((game) => {
+			collection.append (game);
 		});
+
+		collection_icon_view.model = collection;
 	}
+
+	[GtkCallback]
+	private void on_game_activated (Game game) {
+		// TODO
+	}
+
 }

--- a/src/ui/application.vala
+++ b/src/ui/application.vala
@@ -1,3 +1,5 @@
+// This file is part of GNOME Games. License: GPLv3
+
 using Gtk;
 
 public class Games.Application : Gtk.Application {

--- a/src/ui/application.vala
+++ b/src/ui/application.vala
@@ -9,6 +9,10 @@ public class Games.Application : Gtk.Application {
 	protected override void activate () {
 		Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
 
+		var screen = Gdk.Screen.get_default ();
+		var provider = load_css ("gtk-style.css");
+		Gtk.StyleContext.add_provider_for_screen (screen, provider, 600);
+
 		var window = new ApplicationWindow ();
 		this.add_window (window);
 		window.destroy.connect (() => {
@@ -17,5 +21,17 @@ public class Games.Application : Gtk.Application {
 		window.load_game_list ();
 		window.show_all ();
 	}
+
+	private static Gtk.CssProvider load_css (string css) {
+		var provider = new CssProvider ();
+		try {
+			var file = File.new_for_uri("resource:///org/gnome/Games/" + css);
+			provider.load_from_file (file);
+		} catch (GLib.Error e) {
+			warning ("Loading CSS file '%s'failed: %s", css, e.message);
+		}
+		return provider;
+	}
+
 }
 

--- a/src/ui/collection-icon-view.vala
+++ b/src/ui/collection-icon-view.vala
@@ -1,0 +1,48 @@
+// This file is part of GNOME Games. License: GPLv3
+
+[GtkTemplate (ui = "/org/gnome/Games/ui/collection-icon-view.ui")]
+private class Games.CollectionIconView : Gtk.ScrolledWindow {
+	public signal void game_activated (Game game);
+
+	private ListModel _model;
+	public ListModel model {
+		get { return _model; }
+		set {
+			_model = value;
+
+			clear_content ();
+			for (int i = 0 ; i < model.get_n_items () ; i++) {
+				var game = model.get_item (i) as Game;
+				var game_view = new GameIconView (game);
+				var child = new Gtk.FlowBoxChild ();
+
+				game_view.visible = true;
+				child.visible = true;
+
+				child.add (game_view);
+				flow_box.add (child);
+			}
+		}
+	}
+
+	[GtkChild]
+	private Gtk.FlowBox flow_box;
+
+	construct {
+		flow_box.max_children_per_line = uint.MAX;
+	}
+
+	[GtkCallback]
+	private void on_child_activated (Gtk.FlowBoxChild child) {
+		if (child.get_child () is GameIconView)
+			on_game_view_activated (child.get_child () as GameIconView);
+	}
+
+	private void on_game_view_activated (GameIconView game_view) {
+		game_activated (game_view.game);
+	}
+
+	private void clear_content () {
+		flow_box.forall ((child) => { flow_box.remove (child); });
+	}
+}

--- a/src/ui/game-icon-view.vala
+++ b/src/ui/game-icon-view.vala
@@ -1,0 +1,29 @@
+// This file is part of GNOME Games. License: GPLv3
+
+[GtkTemplate (ui = "/org/gnome/Games/ui/game-icon-view.ui")]
+private class Games.GameIconView : Gtk.Box {
+	private Game _game;
+	public Game game {
+		get { return _game; }
+		set {
+			if (value == game)
+				return;
+
+			_game = value;
+
+			thumbnail.game = game;
+			title.label = game.name;
+
+			queue_draw ();
+		}
+	}
+
+	[GtkChild]
+	private GameThumbnail thumbnail;
+	[GtkChild]
+	private Gtk.Label title;
+
+	public GameIconView (Game game) {
+		this.game = game;
+	}
+}

--- a/src/ui/game-thumbnail.vala
+++ b/src/ui/game-thumbnail.vala
@@ -1,0 +1,118 @@
+// This file is part of GNOME Boxes. License: LGPLv2+
+
+//[GtkTemplate (ui = "/org/gnome/Boxes/ui/game-list-thumbnail.ui")]
+private class Games.GameThumbnail: Gtk.DrawingArea {
+	private const Gtk.CornerType[] right_corners = { Gtk.CornerType.TOP_RIGHT, Gtk.CornerType.BOTTOM_RIGHT };
+	private const Gtk.CornerType[] bottom_corners = { Gtk.CornerType.BOTTOM_LEFT, Gtk.CornerType.BOTTOM_RIGHT };
+
+	private const double ICON_SCALE = 0.75;
+	private const double FRAME_RADIUS = 2;
+	private const int EMBLEM_PADDING = 8;
+
+	public int center_emblem_size { set; get; default = 16; }
+	public int secondary_emblem_size { set; get; default = 8; }
+
+	private Game _game;
+	public Game game {
+		get { return _game; }
+		set {
+			if (_game == value)
+				return;
+
+			_game = value;
+
+			queue_draw ();
+		}
+		default = null;
+	}
+
+	public struct DrawingContext {
+		Cairo.Context cr;
+		Gdk.Window? window;
+		Gtk.StyleContext style;
+		Gtk.StateFlags state;
+		int width;
+		int height;
+	}
+
+	public override bool draw (Cairo.Context cr) {
+		var window = get_window ();
+		var style = get_style_context ();
+		var state = get_state_flags ();
+		var width = get_allocated_width ();
+		var height = get_allocated_height ();
+
+		DrawingContext context = {
+			cr, window, style, state, width, height
+		};
+
+		if (game == null)
+			return false;
+
+		var drawn = false;
+
+		// Draw the default thumbnail if no thumbnail have been drawn
+		if (!drawn)
+			draw_default (context);
+
+		return true;
+	}
+
+	public void draw_default (DrawingContext context) {
+		draw_background (context);
+		draw_emblem_icon (context, "applications-games-symbolic", center_emblem_size);
+		draw_border (context);
+	}
+
+	private void draw_emblem_icon (DrawingContext context, string icon_name, int size) {
+		Gdk.Pixbuf? emblem = null;
+
+		var color = context.style.get_color (context.state);
+
+		var theme = Gtk.IconTheme.get_default ();
+		try {
+			var icon_info = theme.lookup_icon (icon_name, size, Gtk.IconLookupFlags.FORCE_SIZE);
+			emblem = icon_info.load_symbolic (color);
+		} catch (GLib.Error error) {
+			warning (@"Unable to get icon '$icon_name': $(error.message)");
+			return;
+		}
+
+		if (emblem == null)
+			return;
+
+		double offset_x = context.width / 2.0 - emblem.width / 2.0;
+		double offset_y = context.height / 2.0 - emblem.height / 2.0;
+
+		Gdk.cairo_set_source_pixbuf (context.cr, emblem, offset_x, offset_y);
+		context.cr.paint ();
+	}
+
+	private void draw_background (DrawingContext context) {
+		var color = context.style.get_background_color (context.state);
+		context.cr.set_source_rgba (color.red, color.green, color.blue, color.alpha);
+		rounded_rectangle (context.cr, 0.5, 0.5, context.width - 1, context.height - 1, FRAME_RADIUS);
+		context.cr.fill ();
+	}
+
+	private void draw_border (DrawingContext context) {
+		var color = context.style.get_border_color (context.state);
+		context.cr.set_source_rgba (color.red, color.green, color.blue, color.alpha);
+		rounded_rectangle (context.cr, 0.5, 0.5, context.width - 1, context.height - 1, FRAME_RADIUS);
+		context.cr.stroke ();
+	}
+
+	private void rounded_rectangle (Cairo.Context cr, double x, double y, double width, double height, double radius) {
+		const double ARC_0 = 0;
+		const double ARC_1 = Math.PI * 0.5;
+		const double ARC_2 = Math.PI;
+		const double ARC_3 = Math.PI * 1.5;
+
+		cr.new_sub_path ();
+		cr.arc (x + width - radius, y + radius,	         radius, ARC_3, ARC_0);
+		cr.arc (x + width - radius, y + height - radius, radius, ARC_0, ARC_1);
+		cr.arc (x + radius,         y + height - radius, radius, ARC_1, ARC_2);
+		cr.arc (x + radius,         y + radius,          radius, ARC_2, ARC_3);
+		cr.close_path ();
+	}
+}


### PR DESCRIPTION
This replace the icon view by a prettier one relying on GListModel and GtkFlowBox. I have code for icons, covers and screenshots ready, but I don't want to add them until they are supported by a game type.

This is ready for merge IMO.

![Screenshot of the new icon view](blob:http://pasteboard.co/ff6fc7ab-5195-4f4f-a1bc-ec7e854e7840)
