### PR TITLE
game-icon-view: Ellipsize words and chars

### DIFF
--- a/data/ui/game-icon-view.ui
+++ b/data/ui/game-icon-view.ui
@@ -25,7 +25,7 @@
         <property name="lines">2</property>
         <property name="max-width-chars">0</property>
         <property name="wrap">True</property>
-        <property name="wrap-mode">word</property>
+        <property name="wrap-mode">word-char</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -41,7 +41,7 @@
         <property name="lines">1</property>
         <property name="max-width-chars">0</property>
         <property name="wrap">True</property>
-        <property name="wrap-mode">word</property>
+        <property name="wrap-mode">word-char</property>
         <style>
           <class name="dim-label"/>
         </style>


### PR DESCRIPTION
Changes the icon view's labels' ellipsisation from 'word' to
'word-char'.

This prevents the labels to widen the icon view.

Fixes #22
