### PR TITLE
ui: Add ApplicationWindow.remove_runner()

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -51,11 +51,15 @@ private class Games.ApplicationWindow : Gtk.ApplicationWindow {
 		var runner = game.get_runner ();
 		runners[game] = runner;
 
-		runner.stopped.connect (() => {
-			if (runners.contains (game))
-				runners.remove (game);
-		});
+		runner.stopped.connect (remove_runner);
 
 		return runner;
+	}
+
+	private void remove_runner (Runner runner) {
+		foreach (var game in runners.get_keys ()) {
+			if (runners[game] == runner)
+				runners.remove (game);
+		}
 	}
 }


### PR DESCRIPTION
Use a method rather than a closure to remove a runner from the
collection.

This is needed to break a reference cycle caused by the closure and to
ensure that the runners are properly destroyed when quitting the
application.

Fixes #39
