### PR TITLE
ui: Fix DummyDisplay template class name

### DIFF
--- a/data/ui/dummy-display.ui
+++ b/data/ui/dummy-display.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <template class="GamesRemoteDisplay" parent="GtkBox">
+  <template class="GamesDummyDisplay" parent="GtkBox">
     <property name="visible">True</property>
     <property name="hexpand">True</property>
     <property name="vexpand">True</property>


### PR DESCRIPTION
This prevents DummyDisplay to produce crashes.

Fixes #41
