### PR TITLE
ui: Set game name as display title

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -40,6 +40,7 @@ private class Games.ApplicationWindow : Gtk.ApplicationWindow {
 			return;
 		}
 
+		header_bar.game_title = game.name;
 		content_box.runner = runner;
 		ui_state = UiState.DISPLAY;
 

--- a/src/ui/header-bar.vala
+++ b/src/ui/header-bar.vala
@@ -24,6 +24,9 @@ private class Games.HeaderBar : Gtk.Stack {
 		get { return _ui_state; }
 	}
 
+	public string game_title {
+		set { display_header.title = value; }
+	}
 
 	[GtkChild]
 	private Gtk.HeaderBar collection_header;


### PR DESCRIPTION
This allows to know the game's name when playing it.

Fixes #56
