### PR TITLE
doom: Add DoomGame and DoomTrackerQuery

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,9 @@ gnome_games_SOURCES = \
 	core/game-source.vala \
 	core/runner.vala \
 	\
+	doom/doom-game.vala \
+	doom/doom-tracker-query.vala \
+	\
 	dummy/dummy-game.vala \
 	dummy/dummy-game-source.vala \
 	dummy/dummy-runner.vala \

--- a/src/doom/doom-game.vala
+++ b/src/doom/doom-game.vala
@@ -1,0 +1,59 @@
+// This file is part of GNOME Games. License: GPLv3
+
+private class Games.DoomGame : Object, Game {
+	private const string FINGERPRINT_PREFIX = "doom-";
+	private const string MODULE_BASENAME = "libretro-doom.so";
+
+	private string _uid;
+	public string uid {
+		get {
+			if (_uid != null)
+				return _uid;
+
+			var fingerprint = Fingerprint.get_for_file_uri (uri);
+			_uid = FINGERPRINT_PREFIX + fingerprint;
+
+			return _uid;
+		}
+	}
+
+	private string _name;
+	public string name {
+		get { return _name; }
+	}
+
+	public Icon? icon {
+		get { return null; }
+	}
+
+	public Gdk.Pixbuf? cover {
+		get { return null; }
+	}
+
+	public Gdk.Pixbuf? screenshot {
+		get { return null; }
+	}
+
+	public bool running {
+		get { return false; }
+	}
+
+	private string uri;
+	private string path;
+
+	public DoomGame (string uri) throws Error {
+		this.uri = uri;
+
+		var file = File.new_for_uri (uri);
+		path = file.get_path ();
+
+		var name = file.get_basename ();
+		name = /\.(wad|WAD)$/.replace (name, name.length, 0, "");
+		name = name.split ("(")[0];
+		_name = name.strip ();
+	}
+
+	public Runner get_runner () throws RunError {
+		return new RetroRunner (MODULE_BASENAME, path, uid);
+	}
+}

--- a/src/doom/doom-tracker-query.vala
+++ b/src/doom/doom-tracker-query.vala
@@ -1,0 +1,11 @@
+// This file is part of GNOME Games. License: GPLv3
+
+private class Games.DoomTrackerQuery : MimeTypeTrackerQuery {
+	public override string get_mime_type () {
+		return "application/x-doom-wad";
+	}
+
+	public override Game game_for_uri (string uri) throws Error {
+		return new DoomGame (uri);
+	}
+}

--- a/src/ui/application.vala
+++ b/src/ui/application.vala
@@ -69,6 +69,7 @@ public class Games.Application : Gtk.Application {
 
 		tracker_source.add_query (new AmigaTrackerQuery ());
 		tracker_source.add_query (new DesktopTrackerQuery ());
+		tracker_source.add_query (new DoomTrackerQuery ());
 		tracker_source.add_query (new DreamcastTrackerQuery ());
 		tracker_source.add_query (new GameBoyTrackerQuery ());
 		tracker_source.add_query (new GameBoyAdvanceTrackerQuery ());


### PR DESCRIPTION
This allows to list Doom engine game packages.

Fixes #92
