### PR TITLE
ui: Make keyboard shortcuts accept uppercase

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -56,14 +56,14 @@ private class Games.ApplicationWindow : Gtk.ApplicationWindow {
 	public bool on_key_pressed (Gdk.EventKey event) {
 		var default_modifiers = Gtk.accelerator_get_default_mod_mask ();
 
-		if (event.keyval == Gdk.Key.q &&
+		if ((event.keyval == Gdk.Key.q || event.keyval == Gdk.Key.Q) &&
 		    (event.state & default_modifiers) == Gdk.ModifierType.CONTROL_MASK) {
 			destroy ();
 
 			return true;
 		}
 
-		if (event.keyval == Gdk.Key.f &&
+		if ((event.keyval == Gdk.Key.f || event.keyval == Gdk.Key.F) &&
 		    (event.state & default_modifiers) == Gdk.ModifierType.CONTROL_MASK) {
 			if (!search_mode)
 				search_mode = true;


### PR DESCRIPTION
Add the Ctrl+F shortcut in addition to Ctrl+f to trigger the search and
add the Ctrl+Q shortcut in addition to Ctrl+q to quit the application.

This is needed for letter based keyboard shortcuts to work if CapsLock
is set.

Fixes #115
