### PR TITLE
ui: Fix GtkHeaderBar runtime warnings

### DIFF
--- a/data/ui/header-bar.ui
+++ b/data/ui/header-bar.ui
@@ -32,8 +32,6 @@
           </object>
           <packing>
             <property name="pack-type">end</property>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Remove the 'expand' and 'fill' packing properties from the collection
header bar as these are invalid properties.

This fixes runtime warnings.

Fixes #136
