### PR TITLE
Remove unused properties from games

### DIFF
--- a/src/commodore/amiga-game.vala
+++ b/src/commodore/amiga-game.vala
@@ -26,18 +26,6 @@ private class Games.AmigaGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/doom/doom-game.vala
+++ b/src/doom/doom-game.vala
@@ -26,18 +26,6 @@ private class Games.DoomGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nec/pc-engine-game.vala
+++ b/src/nec/pc-engine-game.vala
@@ -26,18 +26,6 @@ private class Games.PcEngineGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/game-boy-advance-game.vala
+++ b/src/nintendo/game-boy-advance-game.vala
@@ -26,18 +26,6 @@ private class Games.GameBoyAdvanceGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/game-boy-game.vala
+++ b/src/nintendo/game-boy-game.vala
@@ -26,18 +26,6 @@ private class Games.GameBoyGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/game-cube-game.vala
+++ b/src/nintendo/game-cube-game.vala
@@ -26,18 +26,6 @@ private class Games.GameCubeGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/nes-game.vala
+++ b/src/nintendo/nes-game.vala
@@ -26,18 +26,6 @@ private class Games.NesGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/nintendo-64-game.vala
+++ b/src/nintendo/nintendo-64-game.vala
@@ -26,18 +26,6 @@ private class Games.Nintendo64Game : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/nintendo-ds-game.vala
+++ b/src/nintendo/nintendo-ds-game.vala
@@ -26,18 +26,6 @@ private class Games.NintendoDsGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/snes-game.vala
+++ b/src/nintendo/snes-game.vala
@@ -34,18 +34,6 @@ private class Games.SnesGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/wii-game.vala
+++ b/src/nintendo/wii-game.vala
@@ -26,18 +26,6 @@ private class Games.WiiGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/nintendo/wii-ware-game.vala
+++ b/src/nintendo/wii-ware-game.vala
@@ -26,18 +26,6 @@ private class Games.WiiWareGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/sega/dreamcast-game.vala
+++ b/src/sega/dreamcast-game.vala
@@ -26,18 +26,6 @@ private class Games.DreamcastGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/sega/master-system-game.vala
+++ b/src/sega/master-system-game.vala
@@ -26,18 +26,6 @@ private class Games.MasterSystemGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/sega/mega-drive-game.vala
+++ b/src/sega/mega-drive-game.vala
@@ -26,18 +26,6 @@ private class Games.MegaDriveGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 

--- a/src/sega/sega-saturn-game.vala
+++ b/src/sega/sega-saturn-game.vala
@@ -26,18 +26,6 @@ private class Games.SegaSaturnGame : Object, Game {
 		get { return null; }
 	}
 
-	public Gdk.Pixbuf? cover {
-		get { return null; }
-	}
-
-	public Gdk.Pixbuf? screenshot {
-		get { return null; }
-	}
-
-	public bool running {
-		get { return false; }
-	}
-
 	private string uri;
 	private string path;
 


### PR DESCRIPTION
Remove the unused 'cover', 'screenshot' and 'running' properties from
Retro based games.

This makes the code cleaner.

Fixes #141
