### PR TITLE
retro: Add RetroLog

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,6 +65,7 @@ gnome_games_SOURCES = \
 	nintendo/wii-ware-game.vala \
 	nintendo/wii-ware-tracker-query.vala \
 	\
+	retro/retro-log.vala \
 	retro/retro-runner.vala \
 	\
 	sega/dreamcast-game.vala \

--- a/src/retro/retro-log.vala
+++ b/src/retro/retro-log.vala
@@ -1,0 +1,28 @@
+// This file is part of GNOME Games. License: GPLv3
+
+public class Games.RetroLog: Object, Retro.Log {
+	public bool log (Retro.LogLevel level, string message) {
+		switch (level) {
+		case Retro.LogLevel.DEBUG:
+			GLib.debug (message);
+
+			break;
+		case Retro.LogLevel.INFO:
+			GLib.info (message);
+
+			break;
+		case Retro.LogLevel.WARN:
+			GLib.warning (message);
+
+			break;
+		case Retro.LogLevel.ERROR:
+			GLib.critical (message);
+
+			break;
+		default:
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/retro/retro-runner.vala
+++ b/src/retro/retro-runner.vala
@@ -55,7 +55,7 @@ private class Games.RetroRunner : Object, Runner {
 	private RetroGtk.Keyboard keyboard;
 	private RetroGtk.InputDeviceManager input;
 	private Retro.Options options;
-	private Retro.FileStreamLog log;
+	private RetroLog log;
 	private Retro.Loop loop;
 
 	private Gtk.EventBox widget;
@@ -152,7 +152,7 @@ private class Games.RetroRunner : Object, Runner {
 		audio = new RetroGtk.PaPlayer ();
 		input = new RetroGtk.InputDeviceManager ();
 		options = new Retro.Options ();
-		log = new Retro.FileStreamLog (stderr);
+		log = new RetroLog ();
 
 		input.set_controller_device (0, gamepad);
 		input.set_keyboard (keyboard);


### PR DESCRIPTION
Make RetroRunner's core log using GLib logging functions rather than
simply printing to stderr with colors.

Fixes #148
