### PR TITLE
steam-registry: Make "" a valid token

### DIFF
--- a/src/steam/steam-registry.vala
+++ b/src/steam/steam-registry.vala
@@ -71,7 +71,7 @@ private class Games.SteamRegistry {
 
 		string[] tokens = {};
 
-		var regex = /({|}|(?:".+?"))/;
+		var regex = /({|}|(?:".*?"))/;
 
 		string line;
 		MatchInfo match_info;


### PR DESCRIPTION
This allows registry files containing empty strings to be tokenized and
parsed as expected.

Fixes #170
