### PR TITLE
application: Lower missing Steam log level

### DIFF
--- a/src/ui/application.vala
+++ b/src/ui/application.vala
@@ -93,7 +93,7 @@ public class Games.Application : Gtk.Application {
 			steam_source = new SteamGameSource ();
 		}
 		catch (Error e) {
-			warning ("Can't list Steam games: %s\n'", e.message);
+			debug ("Can't list Steam games: %s\n'", e.message);
 		}
 
 		if (steam_source != null)


### PR DESCRIPTION
Lower the level of the log message notifying the lack of a Steam install
from warning to debug.

This avoids to make a perfectly valid setup appear erroneous.

Fixes #166
