### PR TITLE
tracker-query: Check file exists

### DIFF
--- a/src/desktop/desktop-tracker-query.vala
+++ b/src/desktop/desktop-tracker-query.vala
@@ -9,6 +9,9 @@ private class Games.DesktopTrackerQuery : Object, TrackerQuery {
 		var uri = cursor.get_string (0);
 		var file = File.new_for_uri (uri);
 
+		if (!file.query_exists ())
+			throw new TrackerError.FILE_NOT_FOUND ("Tracker listed file not found: '%s'.", uri);
+
 		var path = file.get_path ();
 		var app_info = new DesktopAppInfo.from_filename (path);
 

--- a/src/tracker/mime-type-tracker-query.vala
+++ b/src/tracker/mime-type-tracker-query.vala
@@ -10,6 +10,10 @@ private abstract class Games.MimeTypeTrackerQuery : Object, TrackerQuery {
 	public Game game_for_cursor (Tracker.Sparql.Cursor cursor) throws Error {
 		var uri = cursor.get_string (0);
 
+		var file = File.new_for_uri (uri);
+		if (!file.query_exists ())
+			throw new TrackerError.FILE_NOT_FOUND ("Tracker listed file not found: '%s'.", uri);
+
 		return game_for_uri (uri);
 	}
 

--- a/src/tracker/tracker-game-source.vala
+++ b/src/tracker/tracker-game-source.vala
@@ -63,6 +63,9 @@ private class Games.TrackerGameSource : Object, GameSource {
 			}
 			catch (TrackerError.GAME_IS_BLACKLISTED e) {
 			}
+			catch (TrackerError.FILE_NOT_FOUND e) {
+				debug (e.message);
+			}
 			catch (Error e) {
 				warning ("Error: %s\n", e.message);
 			}
@@ -81,4 +84,5 @@ private class Games.TrackerGameSource : Object, GameSource {
 
 private errordomain TrackerError {
 	GAME_IS_BLACKLISTED,
+	FILE_NOT_FOUND,
 }


### PR DESCRIPTION
Check whether a file listed by Tracker exists before trying to parse it.

This avoids runtime warnings.

Fixes #178
