### PR TITLE
Prevent error messages from being too wide

### DIFF
--- a/data/ui/error-info-bar.ui
+++ b/data/ui/error-info-bar.ui
@@ -14,6 +14,8 @@
         <child>
           <object class="GtkLabel" id="label">
             <property name="visible">True</property>
+            <property name="wrap">True</property>
+            <property name="wrap-mode">pango-wrap-word-char</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Fix #82 
