### PR TITLE
Remove extra trailing newlines at  end of files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,4 +24,3 @@ indent_style = tab
 indent_size = 8
 tab_size = 8
 indent_style = space
-

--- a/HACKING
+++ b/HACKING
@@ -12,4 +12,3 @@ Add the following to your `~/.config/jhbuildrc`:
 Then:
 
     jhbuild build gnome-games
-

--- a/README
+++ b/README
@@ -1,3 +1,2 @@
 Games is a game manager application for GNOME.
 More information on https://wiki.gnome.org/Design/Playground/Games
-

--- a/autogen.sh
+++ b/autogen.sh
@@ -36,4 +36,3 @@ if [ "$NOCONFIGURE" = "" ]; then
 else
         echo "Skipping configure process."
 fi
-

--- a/plugins/snes/src/snes-game.vala
+++ b/plugins/snes/src/snes-game.vala
@@ -77,4 +77,3 @@ private class Games.SnesGame : Object, Game {
 		return new RetroRunner (MODULE_BASENAME, path, uid_string);
 	}
 }
-

--- a/plugins/steam/src/steam-runner.vala
+++ b/plugins/steam/src/steam-runner.vala
@@ -45,4 +45,3 @@ private class Games.SteamRunner : Object, Runner {
 	public void pause () {
 	}
 }
-

--- a/src/command/command-runner.vala
+++ b/src/command/command-runner.vala
@@ -63,4 +63,3 @@ public class Games.CommandRunner : Object, Runner {
 		stopped ();
 	}
 }
-

--- a/src/retro/retro-runner.vala
+++ b/src/retro/retro-runner.vala
@@ -314,4 +314,3 @@ public class Games.RetroRunner : Object, Runner {
 		}
 	}
 }
-

--- a/src/ui/application.vala
+++ b/src/ui/application.vala
@@ -159,4 +159,3 @@ private class Games.Application : Gtk.Application {
 	}
 
 }
-

--- a/src/ui/dummy-display.vala
+++ b/src/ui/dummy-display.vala
@@ -3,4 +3,3 @@
 [GtkTemplate (ui = "/org/gnome/Games/ui/dummy-display.ui")]
 private class Games.DummyDisplay : Gtk.Box {
 }
-

--- a/src/ui/remote-display.vala
+++ b/src/ui/remote-display.vala
@@ -3,4 +3,3 @@
 [GtkTemplate (ui = "/org/gnome/Games/ui/remote-display.ui")]
 public class Games.RemoteDisplay : Gtk.Box {
 }
-

--- a/src/ui/resume-dialog.vala
+++ b/src/ui/resume-dialog.vala
@@ -6,4 +6,3 @@ private class Games.ResumeDialog : Gtk.Dialog {
 		use_header_bar = 1; // FIXME: Why doesn't this work from UI file?
 	}
 }
-


### PR DESCRIPTION
Currently many files contain extra trailing newlines at end of files.
This commit removes them.

Fixes #252
