### PR TITLE
retro-runner: Add module basename in 'not found' error msg

### DIFF
--- a/src/retro/retro-runner.vala
+++ b/src/retro/retro-runner.vala
@@ -145,7 +145,7 @@ public class Games.RetroRunner : Object, Runner {
 		var module_path = Retro.search_module (module_basename);
 		var module = File.new_for_path (module_path);
 		if (!module.query_exists ()) {
-			var msg = @"Couldn't run game: module '$module_path' not found.";
+			var msg = @"Couldn't run game: module '$module_basename' not found.";
 
 			throw new RetroError.MODULE_NOT_FOUND (msg);
 		}


### PR DESCRIPTION
Replace the module path by its basename in the error message when no
module was found for the given path.

This avoids to have a poorly formated error message when the module path
is empty.

Fix #167
