### PR TITLE
amiga-tracker-query: Set the correct MIME type

### DIFF
--- a/plugins/amiga/src/amiga-tracker-query.vala
+++ b/plugins/amiga/src/amiga-tracker-query.vala
@@ -2,7 +2,7 @@
 
 private class Games.AmigaTrackerQuery : MimeTypeTrackerQuery {
 	public override string get_mime_type () {
-		return "application/x-amiga-disk-file";
+		return "application/x-amiga-disk-format";
 	}
 
 	public override Game game_for_uri (string uri) throws Error {


### PR DESCRIPTION
Set the MIME type to 'application/x-amiga-disk-format' which is the
correct MIME type for Amiga disks.

This allow Amiga games to be properly recognized.

Fixes #260
