### PR TITLE
search-bar: Enable search bar when typing

### DIFF
--- a/data/ui/search-bar.ui
+++ b/data/ui/search-bar.ui
@@ -3,7 +3,6 @@
   <!-- interface-requires gtk+ 3.16 -->
   <template class="GamesSearchBar" parent="GtkSearchBar">
     <property name="visible">True</property>
-    <signal name="notify::search-mode-enabled" handler="on_search_mode_notify"/>
     <child>
       <object class="GtkSearchEntry" id="entry">
         <property name="visible">True</property>

--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -71,6 +71,9 @@ private class Games.ApplicationWindow : Gtk.ApplicationWindow {
 			return true;
 		}
 
+		if (content_box.search_bar_handle_event (event))
+			return true;
+
 		return false;
 	}
 

--- a/src/ui/content-box.vala
+++ b/src/ui/content-box.vala
@@ -107,6 +107,10 @@ private class Games.ContentBox : Gtk.Box {
 		collection_icon_view.filtering_text = search_bar.text;
 	}
 
+	public bool search_bar_handle_event (Gdk.Event event) {
+		return search_bar.handle_event (event);
+	}
+
 	private void set_display (Gtk.Widget display) {
 		remove_display ();
 		display_box.add (display);

--- a/src/ui/search-bar.vala
+++ b/src/ui/search-bar.vala
@@ -8,11 +8,6 @@ private class Games.SearchBar : Gtk.SearchBar {
 	private Gtk.SearchEntry entry;
 
 	[GtkCallback]
-	private void on_search_mode_notify () {
-		entry.text = "";
-	}
-
-	[GtkCallback]
 	private void on_search_changed () {
 		text = entry.text;
 	}


### PR DESCRIPTION
Use SearchBar.handle_event on window keypress

This allows to start searching when typing starts without opening
the search bar.

Fixes #114
