### PR TITLE
application-window: Search only in collection

### DIFF
--- a/src/ui/application-window.vala
+++ b/src/ui/application-window.vala
@@ -71,7 +71,7 @@ private class Games.ApplicationWindow : Gtk.ApplicationWindow {
 			return true;
 		}
 
-		if (content_box.search_bar_handle_event (event))
+		if (ui_state == UiState.COLLECTION && content_box.search_bar_handle_event (event))
 			return true;
 
 		return false;


### PR DESCRIPTION
Check that we are in collection view before triggering search.

This prevents search from taking the key inputs outside of the
collection view, making the keyboard usable again when playing.

Fixes #267
