### PR TITLE
atari-2600: Add the Atari 2600 plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ LT_INIT
 
 # Plugins
 m4_include([plugins/amiga/configure.ac])
+m4_include([plugins/atari-2600/configure.ac])
 m4_include([plugins/desktop/configure.ac])
 m4_include([plugins/doom/configure.ac])
 m4_include([plugins/dreamcast/configure.ac])

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -4,6 +4,10 @@ if ENABLE_AMIGA_PLUGIN
 SUBDIRS += amiga
 endif
 
+if ENABLE_ATARI_2600_PLUGIN
+SUBDIRS += atari-2600
+endif
+
 if ENABLE_DESKTOP_PLUGIN
 SUBDIRS += desktop
 endif

--- a/plugins/atari-2600/Makefile.am
+++ b/plugins/atari-2600/Makefile.am
@@ -1,0 +1,3 @@
+SUBDIRS = data src
+
+include $(top_srcdir)/git.mk

--- a/plugins/atari-2600/configure.ac
+++ b/plugins/atari-2600/configure.ac
@@ -1,0 +1,14 @@
+PKG_CHECK_MODULES(ATARI_2600_PLUGIN, [
+	gio-2.0
+	glib-2.0 >= $GLIB_MIN_VERSION
+	gtk+-3.0
+	tracker-sparql-1.0
+], [enable_atari_2600_plugin=yes], [enable_atari_2600_plugin=no])
+
+AM_CONDITIONAL(ENABLE_ATARI_2600_PLUGIN, test x$enable_atari_2600_plugin != xno)
+
+AC_CONFIG_FILES([
+	plugins/atari-2600/Makefile
+	plugins/atari-2600/data/Makefile
+	plugins/atari-2600/src/Makefile
+])

--- a/plugins/atari-2600/data/Makefile.am
+++ b/plugins/atari-2600/data/Makefile.am
@@ -1,0 +1,6 @@
+EXTRA_DIST = $(plugin_DATA)
+
+plugindir = $(libdir)/gnome-games/plugins
+dist_plugin_DATA = atari-2600.plugin
+
+-include $(top_srcdir)/git.mk

--- a/plugins/atari-2600/data/atari-2600.plugin
+++ b/plugins/atari-2600/data/atari-2600.plugin
@@ -1,0 +1,6 @@
+[Plugin]
+Module=libgames-atari-2600-plugin
+Name=Atari 2600 Plugin
+Description=Provides support for Atari 2600 games.
+Authors=Ricard Gascons <gascons1995@gmail.com>
+Copyright=Copyright © 2016 Ricard Gascons

--- a/plugins/atari-2600/src/Makefile.am
+++ b/plugins/atari-2600/src/Makefile.am
@@ -1,0 +1,53 @@
+plugindir = $(libdir)/gnome-games/plugins
+plugin_LTLIBRARIES = libgames-atari-2600-plugin.la
+
+libgames_atari_2600_plugin_la_DEPENDENCIES = \
+	$(top_builddir)/src/gnome-games.vapi \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_SOURCES = \
+	atari-2600-plugin.vala \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_VALAFLAGS = \
+	--target-glib=@GLIB_MIN_VERSION@ \
+	--pkg gnome-games \
+	--pkg gio-2.0 \
+	--pkg glib-2.0 \
+	--pkg gtk+-3.0 \
+	--pkg tracker-sparql-1.0 \
+	--vapidir $(top_builddir)/src \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_CFLAGS = \
+	$(ATARI_2600_PLUGIN_CFLAGS) \
+	$(GNOME_GAMES_CFLAGS) \
+	-DG_LOG_DOMAIN=\"GamesDesktop\" \
+	-DLOCALEDIR=\"$(localedir)\" \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_CPPFLAGS = \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/src \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_LIBADD = \
+	$(ATARI_2600_PLUGIN_LIBS) \
+	$(GNOME_GAMES_LIBS) \
+	$(NULL)
+
+libgames_atari_2600_plugin_la_LDFLAGS = \
+	-no-undefined \
+	-module \
+	-avoid-version \
+	$(NULL)
+
+EXTRA_DIST = \
+	$(plugin_DATA) \
+	$(NULL)
+
+MAINTAINERCLEANFILES = \
+	$(BUILT_SOURCES) \
+	$(NULL)
+
+-include $(top_srcdir)/git.mk

--- a/plugins/atari-2600/src/atari-2600-plugin.vala
+++ b/plugins/atari-2600/src/atari-2600-plugin.vala
@@ -1,0 +1,30 @@
+// This file is part of GNOME Games. License: GPLv3
+
+private class Games.Atari2600 : Object, Plugin {
+	private const string FINGERPRINT_PREFIX = "atari-2600";
+	private const string MIME_TYPE = "application/x-atari-2600-rom";
+	private const string MODULE_BASENAME = "libretro-atari-2600.so";
+
+	public GameSource get_game_source () throws Error {
+		var query = new MimeTypeTrackerQuery (MIME_TYPE, game_for_uri);
+		var connection = Tracker.Sparql.Connection.@get ();
+		var source = new TrackerGameSource (connection);
+		source.add_query (query);
+
+		return source;
+	}
+
+	private static Game game_for_uri (string uri) throws Error {
+		var uid = new FingerprintUid (uri, FINGERPRINT_PREFIX);
+		var title = new FilenameTitle (uri);
+		var cover = new DummyCover ();
+		var runner =  new RetroRunner (MODULE_BASENAME, uri, uid);
+
+		return new GenericGame (title, cover, runner);
+	}
+}
+
+[ModuleInit]
+public Type register_games_plugin (TypeModule module) {
+	return typeof(Games.Atari2600);
+}


### PR DESCRIPTION
Provides support for Atari 2600 games.

Fixes https://github.com/Kekun/gnome-games/issues/109
