### PR TITLE
retro-runner: Use game URI instead of game path

### DIFF
--- a/plugins/amiga/src/amiga-game.vala
+++ b/plugins/amiga/src/amiga-game.vala
@@ -26,14 +26,11 @@ private class Games.AmigaGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public AmigaGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.adf$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.AmigaGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/doom/src/doom-game.vala
+++ b/plugins/doom/src/doom-game.vala
@@ -26,14 +26,11 @@ private class Games.DoomGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public DoomGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.(wad|WAD)$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.DoomGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/dreamcast/src/dreamcast-game.vala
+++ b/plugins/dreamcast/src/dreamcast-game.vala
@@ -25,15 +25,12 @@ private class Games.DreamcastGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 	private DreamcastHeader header;
 
 	public DreamcastGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		header = new DreamcastHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.DreamcastGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/game-boy-advance/src/game-boy-advance-game.vala
+++ b/plugins/game-boy-advance/src/game-boy-advance-game.vala
@@ -26,14 +26,11 @@ private class Games.GameBoyAdvanceGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public GameBoyAdvanceGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.gba$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.GameBoyAdvanceGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/game-boy/src/game-boy-game.vala
+++ b/plugins/game-boy/src/game-boy-game.vala
@@ -26,14 +26,11 @@ private class Games.GameBoyGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public GameBoyGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var header = new GameBoyHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.GameBoyGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/game-cube/src/game-cube-game.vala
+++ b/plugins/game-cube/src/game-cube-game.vala
@@ -25,15 +25,12 @@ private class Games.GameCubeGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 	private GameCubeHeader header;
 
 	public GameCubeGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		header = new GameCubeHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.GameCubeGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/mame/src/mame-game.vala
+++ b/plugins/mame/src/mame-game.vala
@@ -26,14 +26,11 @@ private class Games.MameGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public MameGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var id = file.get_basename ();
 		id = /\.zip$/.replace (id, id.length, 0, "");
 
@@ -50,6 +47,6 @@ private class Games.MameGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/master-system/src/master-system-game.vala
+++ b/plugins/master-system/src/master-system-game.vala
@@ -26,14 +26,11 @@ private class Games.MasterSystemGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public MasterSystemGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var header = new MasterSystemHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.MasterSystemGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/mega-drive/src/mega-drive-game.vala
+++ b/plugins/mega-drive/src/mega-drive-game.vala
@@ -26,14 +26,11 @@ private class Games.MegaDriveGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public MegaDriveGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var header = new MegaDriveHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.MegaDriveGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/neo-geo-pocket/src/neo-geo-pocket-game.vala
+++ b/plugins/neo-geo-pocket/src/neo-geo-pocket-game.vala
@@ -26,14 +26,11 @@ private class Games.NeoGeoPocketGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public NeoGeoPocketGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename();
 		name = /\.ngp$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.NeoGeoPocketGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
  }

--- a/plugins/nes/src/nes-game.vala
+++ b/plugins/nes/src/nes-game.vala
@@ -26,14 +26,11 @@ private class Games.NesGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public NesGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.nes$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.NesGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/nintendo-64/src/nintendo-64-game.vala
+++ b/plugins/nintendo-64/src/nintendo-64-game.vala
@@ -26,14 +26,11 @@ private class Games.Nintendo64Game : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public Nintendo64Game (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.n64$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.Nintendo64Game : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/nintendo-ds/src/nintendo-ds-game.vala
+++ b/plugins/nintendo-ds/src/nintendo-ds-game.vala
@@ -26,14 +26,11 @@ private class Games.NintendoDsGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public NintendoDsGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.nds$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.NintendoDsGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/pc-engine/src/pc-engine-game.vala
+++ b/plugins/pc-engine/src/pc-engine-game.vala
@@ -26,14 +26,11 @@ private class Games.PcEngineGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public PcEngineGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.pce$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.PcEngineGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/sega-saturn/src/sega-saturn-game.vala
+++ b/plugins/sega-saturn/src/sega-saturn-game.vala
@@ -25,22 +25,17 @@ private class Games.SegaSaturnGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 	private SegaSaturnHeader header;
 
 	public SegaSaturnGame (string uri) throws Error {
-		this.uri = uri;
-
 		var file = File.new_for_uri (uri);
-
 		header = new SegaSaturnHeader (file);
 		header.check_validity ();
 
 		var cue = get_associated_cue_sheet (file);
-		path = cue ?? file.get_path ();
+		this.uri = cue ?? uri;
 
-		file = File.new_for_path (path);
-
+		file = File.new_for_uri (this.uri);
 		var name = file.get_basename ();
 		name = /\.(cue|iso|bin)$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -50,7 +45,7 @@ private class Games.SegaSaturnGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 
 	private string? get_associated_cue_sheet (File file) throws Error {
@@ -65,7 +60,7 @@ private class Games.SegaSaturnGame : Object, Game {
 			var type = child_info.get_content_type ();
 
 			if (type == "application/x-cue" && cue_contains_file (child, file))
-				return child.get_path ();
+				return child.get_uri ();
 		}
 
 		return null;

--- a/plugins/snes/src/snes-game.vala
+++ b/plugins/snes/src/snes-game.vala
@@ -34,15 +34,12 @@ private class Games.SnesGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public SnesGame (string uri) throws Error {
 		// Information on SNES header: http://romhack.wikia.com/wiki/SNES_header
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var istream = file.read ();
 
 		var header_offset = HEADER_OFFSET;
@@ -74,7 +71,7 @@ private class Games.SnesGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }
 

--- a/plugins/wii-ware/src/wii-ware-game.vala
+++ b/plugins/wii-ware/src/wii-ware-game.vala
@@ -26,14 +26,11 @@ private class Games.WiiWareGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 
 	public WiiWareGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		var name = file.get_basename ();
 		name = /\.wad$/.replace (name, name.length, 0, "");
 		name = name.split ("(")[0];
@@ -43,6 +40,6 @@ private class Games.WiiWareGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/plugins/wii/src/wii-game.vala
+++ b/plugins/wii/src/wii-game.vala
@@ -25,15 +25,12 @@ private class Games.WiiGame : Object, Game {
 	}
 
 	private string uri;
-	private string path;
 	private WiiHeader header;
 
 	public WiiGame (string uri) throws Error {
 		this.uri = uri;
 
 		var file = File.new_for_uri (uri);
-		path = file.get_path ();
-
 		header = new WiiHeader (file);
 		header.check_validity ();
 
@@ -46,6 +43,6 @@ private class Games.WiiGame : Object, Game {
 	public Runner get_runner () throws Error {
 		var uid_string = uid.get_uid ();
 
-		return new RetroRunner (MODULE_BASENAME, path, uid_string);
+		return new RetroRunner (MODULE_BASENAME, uri, uid_string);
 	}
 }

--- a/src/retro/retro-runner.vala
+++ b/src/retro/retro-runner.vala
@@ -74,7 +74,7 @@ public class Games.RetroRunner : Object, Runner {
 
 	private bool construction_succeeded;
 
-	public RetroRunner (string module_basename, string game_path, string uid) throws Error {
+	public RetroRunner (string module_basename, string uri, string uid) throws Error {
 		construction_succeeded = false;
 
 		this.uid = uid;
@@ -88,7 +88,7 @@ public class Games.RetroRunner : Object, Runner {
 		gamepad = new RetroGtk.VirtualGamepad (widget);
 		keyboard = new RetroGtk.Keyboard (widget);
 
-		prepare_core (module_basename, game_path);
+		prepare_core (module_basename, uri);
 		core.shutdown.connect (on_shutdown);
 
 		core.run (); // Needed to finish preparing some cores.
@@ -141,7 +141,7 @@ public class Games.RetroRunner : Object, Runner {
 		running = true;
 	}
 
-	private void prepare_core (string module_basename, string game_path) throws Error {
+	private void prepare_core (string module_basename, string uri) throws Error {
 		var module_path = Retro.search_module (module_basename);
 		var module = File.new_for_path (module_path);
 		if (!module.query_exists ()) {
@@ -168,14 +168,17 @@ public class Games.RetroRunner : Object, Runner {
 
 		core.init ();
 
-		if (!try_load_game (core, game_path))
-			throw new RetroError.INVALID_GAME_FILE (@"Invalid game file: $game_path");
+		if (!try_load_game (core, uri))
+			throw new RetroError.INVALID_GAME_FILE (@"Invalid game file: $uri");
 	}
 
-	private bool try_load_game (Retro.Core core, string game_name) {
+	private bool try_load_game (Retro.Core core, string uri) {
+		var file = File.new_for_uri (uri);
+		var path = file.get_path ();
+
 		try {
 			var fullpath = core.system_info.need_fullpath;
-			if (core.load_game (fullpath ? Retro.GameInfo (game_name) : Retro.GameInfo.with_data (game_name))) {
+			if (core.load_game (fullpath ? Retro.GameInfo (path) : Retro.GameInfo.with_data (path))) {
 				if (core.disk_control_interface != null) {
 					var disk = core.disk_control_interface;
 
@@ -186,7 +189,7 @@ public class Games.RetroRunner : Object, Runner {
 
 					var index = disk.get_num_images () - 1;
 
-					disk.replace_image_index (index, fullpath ? Retro.GameInfo (game_name) : Retro.GameInfo.with_data (game_name));
+					disk.replace_image_index (index, fullpath ? Retro.GameInfo (path) : Retro.GameInfo.with_data (path));
 
 					disk.set_eject_state (false);
 				}


### PR DESCRIPTION
Construct RetroRunner from a game file URI instead of a game file path.

Avoids converting URIs to paths at multiple places as all
users of RetroRunner have to convert a game file URI into a path in
order to construct it.

This makes the code simpler.

Fixes #278
